### PR TITLE
🔨 Fix: pipe 관련 오류

### DIFF
--- a/inc/CgiHandler.hpp
+++ b/inc/CgiHandler.hpp
@@ -11,7 +11,6 @@
 
 class CgiHandler {
 private:
-    std::vector<char*> argv;
     std::vector<char*> envp;
     std::map<std::string, std::string> env;
 

--- a/src/CgiHandler.cpp
+++ b/src/CgiHandler.cpp
@@ -19,15 +19,13 @@ void CgiHandler::generateProcess(const Request &request)
 
     // 유효하지 않은 path는 404 던지기
 
-    argv.push_back(const_cast<char*>(cgi_path.c_str()));
-    argv.push_back(0);
     if (pid == 0)
     {
         close(fd[0]);
         dup2(fd[1], STDOUT_FILENO);
         fillEnv(request);
         convertEnv();
-        execve(argv[0], &argv[0], &envp[0]);
+        execve(const_cast<char*>(cgi_path.c_str()), NULL, &envp[0]);
         throw std::runtime_error("cgi execute error");
     }
     else

--- a/src/CgiHandler.cpp
+++ b/src/CgiHandler.cpp
@@ -23,12 +23,18 @@ void CgiHandler::generateProcess(const Request &request)
     argv.push_back(0);
     if (pid == 0)
     {
-        close(fd[1]);
-        dup2(fd[0], STDOUT_FILENO);
+        close(fd[0]);
+        dup2(fd[1], STDOUT_FILENO);
         fillEnv(request);
         convertEnv();
         execve(argv[0], &argv[0], &envp[0]);
+        throw std::runtime_error("cgi execute error");
     }
+    else
+    {
+        close(fd[1]);
+    }
+    close(fd[0]);
 }
 
 void CgiHandler::fillEnv(const Request &request)


### PR DESCRIPTION
## 📌 Related Issues
- #3 

## 📝 Description
- pipe fd 번호 잘못 닫아준거 올바르게 변경
- 부모 프로세스에서 안 닫았던 pipe 닫아줌
- `kevent event error` 해결

## 🌳 Working Branch
- `fix/pipe`

## 📚 Etc
- `execve` 실행 시 cgi 스크립트의 경로만 필요해서 `argv` 변수 삭제함
```c++
execve(const_cast<char*>(cgi_path.c_str()), NULL, &envp[0]);
```